### PR TITLE
[DOCS] Update docs

### DIFF
--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -1,0 +1,19 @@
+[general]
+
+project     = PHP Content Element
+version     = main (development)
+release     = main (development)
+copyright   = since 2017 by joppnet
+
+[html_theme_options]
+
+# "Edit on GitHub" button
+github_repository    = joppnet/jn_phpcontentelement
+github_branch        = master
+
+# Footer links
+project_home         = https://extensions.typo3.org/extension/jn_phpcontentelement
+project_contact      =
+project_repository   = https://github.com/joppnet/jn_phpcontentelement
+project_issues       = https://github.com/joppnet/jn_phpcontentelement/issues
+project_discussions  =

--- a/README.md
+++ b/README.md
@@ -1,28 +1,26 @@
-# Ext: jn_phpcontentelement
+[![TYPO3 11](https://img.shields.io/badge/TYPO3-11-orange.svg)](https://get.typo3.org/version/11)
+[![TYPO3 10](https://img.shields.io/badge/TYPO3-10-orange.svg)](https://get.typo3.org/version/10)
 
-<img src="https://www.joppnet.de/typo3conf/ext/jn_phpcontentelement/ext_icon.png" width="32" height="32" />
+# TYPO3 extension `jn_phpcontentelement`
 
-License: [GNU GPL, Version 2](https://www.gnu.org/licenses/gpl-2.0.html)
+This extension allows you to add PHP scripts via content elements.
 
-Repository: https://github.com/joppnet/jn_phpcontentelement
-
-Please report bugs here: https://github.com/joppnet/jn_phpcontentelement/issues
-
-TYPO3 version: >10.4
-
-## About
-Allows you to add PHP scripts via frontend plugin.
+|                  | URL                                                               |
+|------------------|-------------------------------------------------------------------|
+| **Repository:**  | https://github.com/joppnet/jn_phpcontentelement                   |
+| **Read online:** | https://docs.typo3.org/p/joppnet/jn_phpcontentelement/main/en-us/ |
+| **TER:**         | https://extensions.typo3.org/extension/jn_phpcontentelement       |
 
 ## Installation & Configuration
 
-1. Install the extension "jn_phpcontentelement" in your TYPO3 extension manager
-2. Include the static TypoScript template "[joppnet] PHP Content Element" to the root page
+1. Install the extension "jn_phpcontentelement" in your TYPO3 Extension Manager or via Composer.
+2. Include the static TypoScript template "[joppnet] PHP Content Element" in the root page.
      
 ## Usage
 
-1. In List view, add a new "PHP Content Element" record.
+1. In List view, add a new "PHP Content" record.
 <img src="https://www.joppnet.de/typo3conf/ext/jn_phpcontentelement/Resources/Public/Manual/manual-record.png" />
-2. In Page view, add a new plugin content element "[joppnet] PHP Content Element".
+2. In Page view, add a new "[joppnet] PHP Content Element" plugin content element.
 <img src="https://www.joppnet.de/typo3conf/ext/jn_phpcontentelement/Resources/Public/Manual/manual-ce.png" />
 3. Select the page where you created the records from the previous step in the "Record Storage Page" select field.
 <img src="https://www.joppnet.de/typo3conf/ext/jn_phpcontentelement/Resources/Public/Manual/manual-record-storage.png" />


### PR DESCRIPTION
Hi Oliver, hello joppnet-Team,

i just came across your extension documentation while having a look at intercept. This PR is to align with similar documentations, that want to improve the guiding of the user. It provides him or her with all required information, especially with links to the next steps like vcs repository, installation and full documentation and fixes some texts.

There will be soon a TYPO3 documentation guideline for my adaptions, which is currently under review.

These todos remain:

1. The image `manual-record.png` does not show the "PHP Content" record but the "PHP Content Element" content element and should better be fixed.
2. Consider to [publish your extension automatically](https://github.com/tomasnorre/typo3-upload-ter) to TER and Packagist on updates. For example, see this [GitHub workflow](https://github.com/FriendsOfTYPO3/extension_builder/blob/master/.github/workflows/publish.yml) of the Extension Builder.

Greetings, Alex

Related: https://github.com/TYPO3-Documentation/T3DocTeam/issues/182
