### PR TITLE
[TASK] Align with new TYPO3 documentation standards (follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
+[![Latest Stable Version](https://poser.pugx.org/joppnet/jn_phpcontentelement/v/stable.svg)](https://extensions.typo3.org/extension/jn_phpcontentelement/)
 [![TYPO3 11](https://img.shields.io/badge/TYPO3-11-orange.svg)](https://get.typo3.org/version/11)
 [![TYPO3 10](https://img.shields.io/badge/TYPO3-10-orange.svg)](https://get.typo3.org/version/10)
+[![Total Downloads](https://poser.pugx.org/joppnet/jn_phpcontentelement/d/total.svg)](https://packagist.org/packages/joppnet/jn_phpcontentelement)
+[![Monthly Downloads](https://poser.pugx.org/joppnet/jn_phpcontentelement/d/monthly)](https://packagist.org/packages/joppnet/jn_phpcontentelement)
 
 # TYPO3 extension `jn_phpcontentelement`
 

--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,9 @@
 		"ce",
 		"content"
 	],
-	"homepage": "https://github.com/joppnet/jn_phpcontentelement",
+	"homepage": "https://extensions.typo3.org/extension/jn_phpcontentelement",
 	"support": {
-		"docs": "https://github.com/joppnet/jn_phpcontentelement",
+		"docs": "https://docs.typo3.org/p/joppnet/jn_phpcontentelement/main/en-us/",
 		"issues": "https://github.com/joppnet/jn_phpcontentelement/issues",
 		"source": "https://github.com/joppnet/jn_phpcontentelement"
 	},


### PR DESCRIPTION
Added two new commits regarding badges in README and additional sources (TER, repository and docs.typo3.org) in composer.json.

Relates: TYPO3-Documentation/T3DocTeam#185